### PR TITLE
UML-2926 Store images on-disk instead of in-memory

### DIFF
--- a/lambdas/image_processor/app/utility/extraction_service.py
+++ b/lambdas/image_processor/app/utility/extraction_service.py
@@ -1,6 +1,7 @@
 import datetime
 import copy
 import os
+import tempfile
 
 import cv2
 import re
@@ -17,6 +18,8 @@ from form_tools.utils.image_reader import ImageReader
 from app.utility.custom_logging import custom_logger
 from app.utility.bucket_manager import ScanLocationStore
 from typing import List
+from PIL import UnidentifiedImageError
+
 
 logger = custom_logger("extraction_service")
 
@@ -119,7 +122,6 @@ class ExtractionService:
             meta_id = matched_document_items.meta_id
             meta = complete_meta_store[meta_id]
             document_path = matched_document_store_item.scan_location
-
             self.extract_images(
                 matched_document_items,
                 meta,
@@ -130,11 +132,9 @@ class ExtractionService:
                 fail_dir,
                 run_timestamp,
             )
-
             # If the key contains "continuation_", add it to the list of continuation keys to use
             if "continuation_" in key:
                 continuation_keys_to_use.append(key)
-
         return continuation_keys_to_use
 
     @staticmethod
@@ -241,6 +241,11 @@ class ExtractionService:
             processed_images = self.get_preprocessed_images(
                 scan_location.location, form_operator
             )
+
+            if processed_images == None:
+                logger.debug(f"No processed images in {scan_location.location}.")
+                continue
+
             logger.debug(
                 f"Attempting to match {scan_location.template} - {scan_location.location} based on barcodes..."
             )
@@ -279,12 +284,18 @@ class ExtractionService:
             processed_images = self.get_preprocessed_images(
                 scan_location.location, form_operator
             )
+
+            if processed_images == None:
+                logger.debug(f"No processed images in {scan_location.location}.")
+                continue
+
             matched_items = self.get_ocr_matches(
                 processed_images,
                 form_operator,
                 filtered_metastore,
                 scan_location.location,
             )
+
             if len(matched_items.image_page_map) > 0:
                 matching_item = MatchingItem(matched_items, scan_location.location)
                 matched_lpa_scans_store = MatchingItemsStore()
@@ -329,6 +340,10 @@ class ExtractionService:
             processed_images = self.get_preprocessed_images(
                 scan_location.location, form_operator
             )
+
+            if processed_images == None:
+                logger.debug(f"No processed images in {scan_location.location}.")
+                continue
 
             logger.debug(
                 f"Attempting to match {scan_location.location} based on barcodes..."
@@ -454,14 +469,24 @@ class ExtractionService:
             list: A list of preprocessed form images after being auto-rotated based on text direction.
         """
         logger.debug(f"Reading form from path: {form_path}")
-        _, imgs = ImageReader.read(form_path)
 
-        logger.debug("Auto-rotating images based on text direction...")
-        rotated_images = form_operator.auto_rotate_form_images(imgs)
+        try:
+            with tempfile.TemporaryDirectory() as path:
+                _, imgs = ImageReader.read(
+                    form_path, conversion_parameters={"output_folder": path}
+                )
+
+                logger.debug("Auto-rotating images based on text direction...")
+                rotated_images = form_operator.auto_rotate_form_images(imgs)
+
+                return rotated_images
+        except UnidentifiedImageError:
+            logger.debug(f"Unable to match {form_path}")
+            pass
 
         logger.debug(f"Total images found: {len(rotated_images)}")
 
-        return rotated_images
+        return None
 
     @staticmethod
     def smart_threshold_images(image_list):

--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -53,6 +53,7 @@ module "processor_lamdba" {
   security_group_ids = [data.aws_security_group.lambda_api_ingress.id]
   logs_kms_key       = data.aws_kms_key.lpa_iap_logs
   retention_in_days  = 365
+  ephemeral_storage  = 10240
 }
 
 # Needed for next lambda

--- a/terraform/environment/modules/lambda/main.tf
+++ b/terraform/environment/modules/lambda/main.tf
@@ -22,6 +22,10 @@ resource "aws_lambda_function" "lambda_function" {
     mode = "Active"
   }
 
+  ephemeral_storage {
+    size = var.ephemeral_storage
+  }
+
   dynamic "environment" {
     for_each = length(keys(var.environment_variables)) == 0 ? [] : [true]
     content {

--- a/terraform/environment/modules/lambda/variables.tf
+++ b/terraform/environment/modules/lambda/variables.tf
@@ -100,3 +100,9 @@ variable "logs_kms_key" {
 variable "retention_in_days" {
   description = "Log retention in days"
 }
+
+variable "ephemeral_storage" {
+  description = "The amount of Ephemeral storage (/tmp) to allocate for the Lambda Function in MB"
+  type        = number
+  default     = 512
+}


### PR DESCRIPTION
# Purpose

Images are currently stored in-memory instead of on-disk when being processed. This is leading to OOM errors in Lambda for documents with a lot of pages. Increase the ephemeral storage from 512MB to 10GB and places the images in the /tmp directory.

Fixes UML-2926

## Approach

_Explain how your code addresses the purpose of the change._

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
