### PR TITLE
COLLECTION_ERROR needs to result in a 200 rather than a 500 response

### DIFF
--- a/lambdas/image_request_handler/app/handler.py
+++ b/lambdas/image_request_handler/app/handler.py
@@ -89,7 +89,7 @@ class ImageRequestHandler:
                 "body": json.dumps(message),
             }
         except Exception as e:
-            status_code = 500
+            status_code = 200
             logger.error(
                 e, extra=get_event_details_for_logs(self.event, status=status_code)
             )

--- a/lambdas/image_request_handler/tests/handler_test.py
+++ b/lambdas/image_request_handler/tests/handler_test.py
@@ -328,7 +328,7 @@ def test_process_request(image_request_handler):
     stubber.activate()
     response = image_request_handler.process_request()
     response_body = json.loads(response["body"])
-    assert response["statusCode"] == 500
+    assert response["statusCode"] == 200
     assert response_body["status"] == "COLLECTION_ERROR"
 
     # Mock that collection has now completed


### PR DESCRIPTION
# Purpose

_A collection error should result in a 200 from the lambda not a 500._


## Approach

_change the return code_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
