### PR TITLE
UML-2937 Reduce images in memory in image processor

### DIFF
--- a/lambdas/image_processor/app/handler.py
+++ b/lambdas/image_processor/app/handler.py
@@ -98,6 +98,7 @@ class ImageProcessor:
             # Cleanup all the folders
             self.cleanup(downloaded_scan_locations)
             logger.debug("Cleaned down paths")
+            self.print_files('/tmp')
 
             self.info_msg.status = "Completed"
             logger.info(json.dumps(self.info_msg.get_info_message()))
@@ -108,6 +109,16 @@ class ImageProcessor:
             error_message = f"{self.request_id} {e} --- {stack_trace}"
             logger.error(error_message)
             bucket_manager.put_error_image_to_bucket(self.uid)
+
+    @staticmethod
+    def print_files(startpath):
+        for root, dirs, files in os.walk(startpath):
+            level = root.replace(startpath, '').count(os.sep)
+            indent = ' ' * 4 * (level)
+            print('{}{}/'.format(indent, os.path.basename(root)))
+            subindent = ' ' * 4 * (level + 1)
+            for f in files:
+                print('{}{}'.format(subindent, f))
 
     @staticmethod
     def get_timestamp_as_str() -> str:
@@ -149,7 +160,7 @@ class ImageProcessor:
         - A list of file paths (str) that match the specified file type.
         """
         paths = []
-        for root, dirs, files in os.walk(filepath):
+        for root, _, files in os.walk(filepath):
             for file in files:
                 if file.lower().endswith(filetype.lower()):
                     paths.append(os.path.join(root, file))
@@ -169,7 +180,7 @@ class ImageProcessor:
             downloaded_document_paths.append(path.location)
 
         # Extract the paths from the 'continuations' keys and add them to the list
-        for key, path in downloaded_document_locations.continuations.items():
+        for _, path in downloaded_document_locations.continuations.items():
             downloaded_document_paths.append(path.location)
 
         # Remove downloaded images

--- a/lambdas/image_processor/app/utility/image_reader.py
+++ b/lambdas/image_processor/app/utility/image_reader.py
@@ -1,0 +1,95 @@
+import cv2
+import numpy as np
+
+from PIL import Image
+from pdf2image import convert_from_bytes
+from typing import List, Optional, ByteString, Dict, Any
+import uuid
+
+class ImageReader:
+    """ImageReader utility class
+
+    General purpose class for reading PDF files from a local
+    path.
+    """
+
+    @staticmethod
+    def _convert_PIL_to_cv2(image: Image) -> np.ndarray:
+        """Convert Pillow image to a opencv image
+
+        Takes a Pillow image and returns an numpy
+        ndarray corresponding to an opencv image.
+
+        Params:
+            image (Image): A Pillow image
+
+        Returns:
+            (str): file path to file containing the ndarray
+        """
+        file_name = f"/tmp/{str(uuid.uuid4())}.npy"
+
+        image = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
+
+        np.save(file_name, image)
+
+        return file_name
+
+    @staticmethod
+    def _read_bytes(file_path: str) -> ByteString:
+        """Reads raw bytes from image file
+
+        Reads an image as raw bytes from a local filepath
+
+        Params:
+            file_path (str): Local filepath to image
+
+        Returns:
+            (ByteString): Byte string for image
+        """
+        with open(file_path, "rb") as img_file:
+            raw_img = img_file.read()
+
+        return raw_img
+
+    @classmethod
+    def read(
+        cls,
+        file_path: str,
+        conversion_parameters: Optional[Dict[str, Any]] = None,
+        **bytes_kwargs,
+    ) -> List[np.ndarray]:
+        """reader method
+
+        The reader method for pdf image files. Uses `pdf2image`
+        `convert_from_bytes` to convert a pdf byte string to
+        a list of opencv images saved as .npy files.
+
+        Params:
+            file_path (str): Local filepath to image
+            conversion_parameters (Optional[Dict[str, Any]]):
+                Options to pass to `pdf2image.convert_from_bytes`
+            **bytes_kwargs: Optional keyword arguments to pass onto
+                `_read_bytes` method.
+
+        Returns:
+            Tuple[bool, List[str]]: Tuple where
+                first entry specifies whether the result
+                is a multipage image, and the second the
+                list of file paths containing the ndarrays of the images
+        """
+        # tracemalloc.start()
+
+        raw_img = cls._read_bytes(file_path, **bytes_kwargs)
+        if conversion_parameters is None:
+            conversion_parameters = {}
+
+        converted_imgs = convert_from_bytes(raw_img, **conversion_parameters)
+
+        if isinstance(converted_imgs, list):
+            cv2_images = [cls._convert_PIL_to_cv2(img) for img in converted_imgs]
+            multipage = True if len(cv2_images) > 1 else False
+        else:
+            cv2_images = [cls._convert_PIL_to_cv2(converted_imgs)]
+            multipage = False
+
+        return multipage, cv2_images

--- a/lambdas/image_processor/app/utility/ocr.py
+++ b/lambdas/image_processor/app/utility/ocr.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from tesserocr import PyTessBaseAPI, PSM
+
+
+def _convert_cv2_to_bytes(image: np.ndarray):
+    image_bytes = image.tobytes()
+    bpp = image.shape[2] if len(image.shape) == 3 else 1
+    h, w = image.shape[0:2]
+    bpl = bpp * w
+    return image_bytes, w, h, bpp, bpl
+
+
+def get_text_from_image_file(image_locations: list[str]) -> list:
+    api_kwargs = {"psm": PSM.AUTO_OSD, "lang": "eng"}
+    api = PyTessBaseAPI(**api_kwargs)
+
+    list_of_text = []
+    for image_location in image_locations:
+        image = np.load(image_location)
+        image_bytes = _convert_cv2_to_bytes(image)
+        api.SetImageBytes(*image_bytes)
+        api.Recognize()
+        text = api.GetUTF8Text()
+
+        list_of_text.append(text)
+
+    return list_of_text

--- a/terraform/environment/api_rest.tf
+++ b/terraform/environment/api_rest.tf
@@ -1,12 +1,7 @@
-data "template_file" "_" {
-  template = local.openapi_spec
-  vars     = local.api_template_vars
-}
-
-resource "aws_api_gateway_rest_api" "lpa_iap" {
+  resource "aws_api_gateway_rest_api" "lpa_iap" {
   name        = "lpa-instructions-preferences-${local.environment}"
   description = "API Gateway for LPA instructions and preferences - ${local.environment}"
-  body        = data.template_file._.rendered
+  body        = templatefile(local.openapi_spec, local.api_template_vars)
 
   endpoint_configuration {
     types = ["REGIONAL"]

--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -41,7 +41,7 @@ module "processor_lamdba" {
     TARGET_ENVIRONMENT = local.account.target_environment
     SECRET_PREFIX      = local.account.secret_prefix
     SIRIUS_URL_PART    = "/api/public/v1"
-    LOGGER_LEVEL       = "INFO"
+    LOGGER_LEVEL       = "DEBUG"
   }
   image_uri          = "${data.aws_ecr_repository.lpa_iap_processor.repository_url}:${var.image_tag}"
   ecr_arn            = data.aws_ecr_repository.lpa_iap_request_handler.arn


### PR DESCRIPTION
# Purpose

Reduce memory usage of Lambda function

Fixes UML-2937

## Approach

Reduce the amount of images residing in memory on the image processor to prevent OOM killer from pre-maturing ending the Lambda function.

Save images to disk and load to memory as and when needed rather than keeping in memory.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have added relevant logging with appropriate levels to my code
* [X] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
