### PR TITLE
UML-2940 Remove use of template_file resource in TF

### DIFF
--- a/terraform/environment/api_rest.tf
+++ b/terraform/environment/api_rest.tf
@@ -1,12 +1,7 @@
-data "template_file" "_" {
-  template = local.openapi_spec
-  vars     = local.api_template_vars
-}
-
 resource "aws_api_gateway_rest_api" "lpa_iap" {
   name        = "lpa-instructions-preferences-${local.environment}"
   description = "API Gateway for LPA instructions and preferences - ${local.environment}"
-  body        = data.template_file._.rendered
+  body        = templatefile("../../docs/openapi/${local.api_name}.yml", local.api_template_vars)
 
   endpoint_configuration {
     types = ["REGIONAL"]


### PR DESCRIPTION
# Purpose

Remove deprecated template_file to allow terraform commands to be run locally

Fixes UML-2940

## Approach

_Explain how your code addresses the purpose of the change._

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
