### PR TITLE
UML-2942 add continuation sheet support for non template sheets

### DIFF
--- a/lambdas/image_processor/app/utility/extraction_service.py
+++ b/lambdas/image_processor/app/utility/extraction_service.py
@@ -81,6 +81,7 @@ class ExtractionService:
         self.output_folder_path = output_folder_path
         self.info_msg = info_msg
         self.matched_continuations_from_scans = MatchingItemsStore()
+        self.complete_meta_store = {}
 
     def run_iap_extraction(self, scan_locations: ScanLocationStore) -> list:
         form_operator = FormOperator.create_from_config(
@@ -89,16 +90,16 @@ class ExtractionService:
         continuation_keys_to_use = []
         run_timestamp = int(datetime.datetime.utcnow().timestamp())
         form_meta_directory = f"{self.extraction_folder_path}/metadata"
-        complete_meta_store = form_operator.form_meta_store(form_meta_directory)
+        self.complete_meta_store = form_operator.form_meta_store(form_meta_directory)
 
         # Find matches based on Scans (only one should match)
         scan_sheet_store = self.get_matching_scan_item(
-            scan_locations, complete_meta_store, form_operator
+            scan_locations, self.complete_meta_store, form_operator
         )
 
         # Find matches based on Continuation sheets (multiple matches possible)
         continuation_sheet_store = self.get_matching_continuation_items(
-            scan_locations, complete_meta_store, form_operator
+            scan_locations, self.complete_meta_store, form_operator
         )
 
         combined_continuation_sheet_store = self.combine_continuation_meta_stores(
@@ -121,7 +122,7 @@ class ExtractionService:
             fail_dir = f"{self.output_folder_path}/fail/{self.folder_name}/{key}"
             matched_document_items = matched_document_store_item.match
             meta_id = matched_document_items.meta_id
-            meta = complete_meta_store[meta_id]
+            meta = self.complete_meta_store[meta_id]
             document_path = matched_document_store_item.scan_location
             self.extract_images(
                 matched_document_items,
@@ -211,6 +212,42 @@ class ExtractionService:
             )
 
     @staticmethod
+    def filter_metastore_based_on_meta_id(
+        complete_meta_store: dict, template: str
+    ) -> FilteredMetastore:
+        metastore_mapping = {
+            "pfa117": {"templates": ["pfa117"], "continuation_templates": ["pfa_c"]},
+            "hw114": {"templates": ["hw114"], "continuation_templates": ["pfa_c"]},
+            "lp1h": {
+                "templates": ["lp1h"],
+                "continuation_templates": ["lpc_as_part_of_scan"],
+            },
+            "lp1f": {
+                "templates": ["lp1f"],
+                "continuation_templates": ["lpc_as_part_of_scan"],
+            },
+        }
+        filtered_metastore = {}
+        filtered_continuation_metastore = {}
+        try:
+            matched_metas = metastore_mapping[template]
+            for matched_meta in matched_metas["templates"]:
+                filtered_metastore[matched_meta] = complete_meta_store[matched_meta]
+            for matched_continuation_meta in matched_metas["continuation_templates"]:
+                filtered_continuation_metastore[
+                    matched_continuation_meta
+                ] = complete_meta_store[matched_continuation_meta]
+            return FilteredMetastore(
+                filtered_metastore=filtered_metastore,
+                filtered_continuation_metastore=filtered_continuation_metastore,
+            )
+        except KeyError:
+            return FilteredMetastore(
+                filtered_metastore=complete_meta_store,
+                filtered_continuation_metastore={},
+            )
+
+    @staticmethod
     def get_pdf_length(file_path):
         with open(file_path, "rb") as file:
             pdf = pypdf.PdfReader(file)
@@ -251,7 +288,7 @@ class ExtractionService:
                 scan_location.location, form_operator
             )
 
-            if processed_images == None:
+            if processed_images is None:
                 logger.debug(f"No processed images in {scan_location.location}.")
                 continue
 
@@ -294,7 +331,7 @@ class ExtractionService:
                 scan_location.location, form_operator
             )
 
-            if processed_images == None:
+            if processed_images is None:
                 logger.debug(f"No processed images in {scan_location.location}.")
                 continue
 
@@ -350,7 +387,7 @@ class ExtractionService:
                 scan_location.location, form_operator
             )
 
-            if processed_images == None:
+            if processed_images is None:
                 logger.debug(f"No processed images in {scan_location.location}.")
                 continue
 
@@ -479,8 +516,8 @@ class ExtractionService:
         """
         logger.debug(f"Reading form from path: {form_path}")
         file_metrics = {
-            'pdfSize': os.stat(form_path).st_size,
-            'pdfLength': self.get_pdf_length(form_path),
+            "pdfSize": os.stat(form_path).st_size,
+            "pdfLength": self.get_pdf_length(form_path),
         }
         logger.info(json.dumps(file_metrics))
         try:
@@ -615,10 +652,19 @@ class ExtractionService:
         if len(scan_and_continuation_matches) == 0:
             return MatchingMetaToImages()
 
+        # ====== Process continuation sheets ======
+        if len(scan_and_continuation_matches) > 0:
+            matched_meta_id = scan_and_continuation_matches[0].meta_id
+            metastore = self.filter_metastore_based_on_meta_id(
+                self.complete_meta_store, matched_meta_id
+            )
+
+            for meta_id, _ in metastore.filtered_continuation_metastore.items():
+                logger.debug(f"OCR continuation metastore: {meta_id}")
+
         if len(metastore.filtered_continuation_metastore) == 0:
             return scan_and_continuation_matches[0]
 
-        # ====== Process continuation sheets ======
         if len(metastore.filtered_continuation_metastore) == 1:
             logger.debug("Further image processing based on continuation template...")
             masked_images = self.mask_images(
@@ -787,6 +833,15 @@ class ExtractionService:
                 return matching_images[0]
 
         # ======= Pull out the continuation matches for in-scan continuations ======
+        if len(matching_images) > 0:
+            matched_meta_id = matching_images[0].meta_id
+            form_metastore = self.filter_metastore_based_on_meta_id(
+                self.complete_meta_store, matched_meta_id
+            )
+
+            for meta_id, _ in form_metastore.filtered_continuation_metastore.items():
+                logger.debug(f"Barcode continuation metastore: {meta_id}")
+
         for (
             continuation_meta_id,
             continuation_meta,

--- a/lambdas/image_processor/tests/handler_test.py
+++ b/lambdas/image_processor/tests/handler_test.py
@@ -10,6 +10,11 @@ test_bucket = "test-bucket"
 event = {"Records": [{"body": '{"uid": "700000000005"}'}]}
 
 
+class FakeContext:
+    def __init__(self, aws_request_id: str = "999999999999"):
+        self.aws_request_id = aws_request_id
+
+
 @pytest.fixture(autouse=True)
 def setup_environment_variables():
     os.environ["ENVIRONMENT"] = "testing"
@@ -18,7 +23,8 @@ def setup_environment_variables():
 
 @pytest.fixture
 def image_processor():
-    return ImageProcessor(event)
+    context = FakeContext()
+    return ImageProcessor(event, context)
 
 
 def test_init_function(image_processor, monkeypatch):

--- a/lambdas/image_processor/tests/utility/extraction_service_test.py
+++ b/lambdas/image_processor/tests/utility/extraction_service_test.py
@@ -316,14 +316,21 @@ def test_get_preprocessed_images(monkeypatch, tmp_path, extraction_service):
         "form_tools.form_operators.FormOperator", lambda: mock_form_operator
     )
 
+    monkeypatch.setattr(
+        extraction_service,
+        "get_pdf_length",
+        MagicMock(return_value=0),
+    )
+
     # Call the function under test
     images = extraction_service.get_preprocessed_images(pdf_path, mock_form_operator)
 
     # Assert that the correct number of images were returned
     assert len(images) == 2
 
-    # Assert that ImageReader.read was called with the correct arguments
-    mock_image_reader.read.assert_called_once_with(pdf_path)
+    # Assert that ImageReader.read was called with the correct path argument
+    actual_args = mock_image_reader.read.call_args
+    assert pdf_path == actual_args[0][0]
 
     # Assert that the form operator methods were called with the correct arguments
     mock_form_operator.auto_rotate_form_images.assert_called_once_with([None, None])


### PR DESCRIPTION
# Purpose

Pick up C sheets where template is not set by sirius

Fixes UML-2942

## Approach

Where we have a match, find out what the template is and filter the store to that cont sheet template.

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
