### PR TITLE
UML-2955: Check if file is PDF before OCR scanning

### DIFF
--- a/lambdas/image_processor/app/utility/extraction_service.py
+++ b/lambdas/image_processor/app/utility/extraction_service.py
@@ -324,6 +324,8 @@ class ExtractionService:
         matches = []
         logger.debug("Attempting to match scans based on OCR...")
         for scan_location in scan_locations.scans:
+            if not self.is_pdf_file(scan_location.location):
+                continue
             filtered_metastore = self.filter_metastore_based_on_template(
                 complete_meta_store, scan_location.template
             )


### PR DESCRIPTION
# Purpose

Resolve the issue where the image processing Lambda won't work for cases which have non-PDF files attached and also require OCR scanning.

Fixes UML-2955

## Approach

Add an is_pdf_file check before OCR scan.

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
