### PR TITLE
UML-2960 Fix barcode scanning issues

### DIFF
--- a/lambdas/image_processor/app/utility/extraction_service.py
+++ b/lambdas/image_processor/app/utility/extraction_service.py
@@ -749,7 +749,19 @@ class ExtractionService:
         for image_count, image in enumerate(images):
             height, width = image.shape[:2]
             roi = image[0 : height // 3, 2 * width // 3 : width]
-            barcodes = decode(roi)
+            roi_resized = cv2.resize(roi, (height, 4 * width))
+            barcodes = decode(roi_resized)
+
+            # If we don't have a barcode, try flipping the image on its axis.
+            # auto_rotate_form_images can cause the image to be upside down, etc.
+            if not barcodes:
+                for i in range(-1, 1):
+                    img_flipped = cv2.flip(image, i)
+                    roi_flipped = img_flipped[0 : height // 3, 2 * width // 3 : width]
+                    roi_flipped_resized = cv2.resize(roi_flipped, (height, 4 * width))
+                    barcodes = decode(roi_flipped_resized)
+                    if barcodes:
+                        break
 
             barcodes_decoded = []
             for barcode in barcodes:


### PR DESCRIPTION
# Purpose

Resolve issues where barcode scans and OCR matching fail on legible PDFs.

Fixes UML-2960

## Approach

Flip the images up to 3 times to check whether the barcode is in a different location.

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes