### PR TITLE
Add saved queries for log insights

### DIFF
--- a/docs/runbooks/common-reporting.md
+++ b/docs/runbooks/common-reporting.md
@@ -1,0 +1,17 @@
+# Common Reporting Requests
+
+Currently, metrics and detailed information about success and failures of the instructions and preferences processing is done adhoc, when requested. As this information is only shown within logs we have created a series of saved queries for log insights to report on this data.
+
+Before running these saved queries please check you have the currect permissions and you are using the correct log group, which should be something like `/aws/lambda/lpa-iap-processor-{environment}`.
+
+## Success / Failure Count
+
+Since launch, this is provided daily for the previous day and should provide numbers for `Completed` (successful) and `Error` (failures). Select the saved query (`Instructions-and-Preferences` -> `Count-By-Status`), the day you want the numbers for and then run that.
+
+This is then shared as text manualy to the team channel.
+
+## Details of Failures
+
+In order to improve the processing and also to check the documents on Sirius we have a query that will find all the failed processes, the case number, the templates / matched documents as well as the reason for the failure. Use the query `Instructions-and-Preferences` -> `Failed-Cases` with the date range you wish to retrieve information for.
+
+Once this the results are shown you can then export the result table as an `xlsx` document. Some tidying on the resulting is helpful (cell wrap, headers, filters), but this document can be provided directly for further investigation.

--- a/terraform/account/log_insights.tf
+++ b/terraform/account/log_insights.tf
@@ -1,6 +1,5 @@
 resource "aws_cloudwatch_query_definition" "iap_count_by_status" {
-  name = "Instructions-and-Preferences/Count-By-Status"
-
+  name         = "Instructions-and-Preferences/Count-By-Status"
   query_string = <<EOF
 # Used to report on the success failure rate of document processing
 fields status, @timestamp, @message
@@ -12,8 +11,7 @@ EOF
 
 
 resource "aws_cloudwatch_query_definition" "iap_error_messages" {
-  name = "Instructions-and-Preferences/Failed-Cases"
-  
+  name         = "Instructions-and-Preferences/Failed-Cases"
   query_string = <<EOF
 # Used to report on which case numbers have failed and the reasons for that failure
 # which is then followed up manually

--- a/terraform/account/log_insights.tf
+++ b/terraform/account/log_insights.tf
@@ -1,0 +1,30 @@
+resource "aws_cloudwatch_query_definition" "iap_count_by_status" {
+  name = "Instructions-and-Preferences/Count-By-Status"
+
+  query_string = <<EOF
+# Used to report on the success failure rate of document processing
+fields status, @timestamp, @message
+| filter ispresent(status)
+| stats count(*) by status
+| sort @timestamp asc
+EOF
+}
+
+
+resource "aws_cloudwatch_query_definition" "iap_error_messages" {
+  name = "Instructions-and-Preferences/Failed-Cases"
+  
+  query_string = <<EOF
+# Used to report on which case numbers have failed and the reasons for that failure
+# which is then followed up manually
+# This can be exported as a xlsx doc directly for eases 
+fields @timestamp, coalesce(@requestId, request_id) as RequestID
+| filter @message like 'ERROR'
+| parse @message 'document_templates": [*]' as DocumentTemplates
+| parse @message 'matched_templates": [*]' as MatchedTemplates
+| parse @message 'ERROR - * *' as pre, ReasonFailed
+| sort @timestamp asc, RequestID asc
+| stats latest(uid) as CaseNumber, latest(ReasonFailed) as Rf, latest(DocumentTemplates) as DocumentTemp, latest(MatchedTemplates) as MatchedTemp by RequestID
+| display @timestamp, CaseNumber, Rf, DocumentTemp, MatchedTemp, RequestID
+EOF
+}

--- a/terraform/account/log_insights.tf
+++ b/terraform/account/log_insights.tf
@@ -18,11 +18,11 @@ resource "aws_cloudwatch_query_definition" "iap_error_messages" {
 # This can be exported as a xlsx doc directly for eases 
 fields @timestamp, coalesce(@requestId, request_id) as RequestID
 | filter @message like 'ERROR'
-| parse @message 'document_templates": [*]' as DocumentTemplates
-| parse @message 'matched_templates": [*]' as MatchedTemplates
-| parse @message 'ERROR - * *' as pre, ReasonFailed
+| parse @message 'document_templates": [*]' as docs
+| parse @message 'matched_templates": [*]' as matched
+| parse @message 'ERROR - * *' as pre, error
 | sort @timestamp asc, RequestID asc
-| stats latest(uid) as CaseNumber, latest(ReasonFailed) as Rf, latest(DocumentTemplates) as DocumentTemp, latest(MatchedTemplates) as MatchedTemp by RequestID
-| display @timestamp, CaseNumber, Rf, DocumentTemp, MatchedTemp, RequestID
+| stats latest(@timestamp) as Time, latest(uid) as CaseNumber, latest(error) as ReasonFailed, latest(docs) as DocumentTemplates, latest(matched) as MatchedTemplates by RequestID
+| display fromMillis(Time) as TimeStamp, CaseNumber, ReasonFailed, DocumentTemplates, MatchedTemplates, RequestID
 EOF
 }


### PR DESCRIPTION
These queries are used for reporting, such as failure percentage and tracking which failed and why
