### PR TITLE
LPAL-2973 Only rotate images when confident wrong

### DIFF
--- a/lambdas/image_processor/requirements-tests.txt
+++ b/lambdas/image_processor/requirements-tests.txt
@@ -1,2 +1,3 @@
 moto==1.3.16
 pytest==6.2.5
+imutils==0.5.4

--- a/lambdas/image_processor/requirements.txt
+++ b/lambdas/image_processor/requirements.txt
@@ -17,3 +17,4 @@ pydantic==1.10.5
 tesserocr==2.5.2
 pyzbar==0.1.9
 fuzzywuzzy[speedup]==0.18.0
+imutils==0.5.4


### PR DESCRIPTION
# Purpose

Only rotate images when confidence is high that it's not aligned properly and the script has been detected as Latin.

Fixes UML-2973

## Approach

Use imutil to rotate the image if Tesseract returns a high confidence level that the image isn't facing the right direction

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
