### PR TITLE
UML-2985 Prefix production image tag with main

### DIFF
--- a/.github/workflows/sub-task-docker-build.yml
+++ b/.github/workflows/sub-task-docker-build.yml
@@ -97,6 +97,7 @@ jobs:
           docker tag ${{ matrix.name }}:latest $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.tag }}
           if [ $BRANCH_NAME == "main" ]; then
             docker tag ${{ matrix.name }}:latest $ECR_REGISTRY/$ECR_REPOSITORY:latest
+            docker tag ${{ matrix.name }}:latest $ECR_REGISTRY/$ECR_REPOSITORY:main-${{ inputs.tag }}
           fi
             echo "skipping push for now..."
             docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY

--- a/.github/workflows/workflow-path-to-live.yml
+++ b/.github/workflows/workflow-path-to-live.yml
@@ -127,7 +127,7 @@ jobs:
     uses: ./.github/workflows/sub-task-terraform.yml
     with:
       terraform_path: 'terraform/account'
-      image_tag: ${{ needs.create_tags.outputs.version_tag }}
+      image_tag: main-${{ needs.create_tags.outputs.version_tag }}
       workspace: preproduction
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
@@ -142,7 +142,7 @@ jobs:
     uses: ./.github/workflows/sub-task-terraform.yml
     with:
       terraform_path: 'terraform/environment'
-      image_tag: ${{ needs.create_tags.outputs.version_tag }}
+      image_tag: main-${{ needs.create_tags.outputs.version_tag }}
       workspace: preproduction
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
@@ -157,7 +157,7 @@ jobs:
     uses: ./.github/workflows/sub-task-terraform.yml
     with:
       terraform_path: 'terraform/account'
-      image_tag: ${{ needs.create_tags.outputs.version_tag }}
+      image_tag: main-${{ needs.create_tags.outputs.version_tag }}
       workspace: production
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
@@ -172,7 +172,7 @@ jobs:
     uses: ./.github/workflows/sub-task-terraform.yml
     with:
       terraform_path: 'terraform/environment'
-      image_tag: ${{ needs.create_tags.outputs.version_tag }}
+      image_tag: main-${{ needs.create_tags.outputs.version_tag }}
       workspace: production
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}


### PR DESCRIPTION
# Purpose

Don't expire production images

Fixes UML-2985

## Approach

Prefix images made during Path to Live with `main` so that they don't expire.

## Learning


## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
