### PR TITLE
UML-3091 Fix config.py for tests

### DIFF
--- a/integration/config.py
+++ b/integration/config.py
@@ -209,7 +209,7 @@ templates = {
             "status": "COLLECTION_COMPLETE",
             "signedUrls": {
                 "iap-700000000096-preferences": "",
-                "iap-700000000096-continuation_instructions_1": "",
+                "iap-700000000096-instructions": "",
                 "iap-700000000096-continuation_preferences_1": "",
                 "iap-700000000096-continuation_preferences_2": "",
                 "iap-700000000096-continuation_preferences_3": "",
@@ -233,11 +233,11 @@ templates = {
             "status": "COLLECTION_COMPLETE",
             "signedUrls": {
                 "iap-700000000097-preferences": "",
-                "iap-700000000097-continuation_instructions_1": "",
+                "iap-700000000097-instructions": "",
                 "iap-700000000097-continuation_preferences_1": "",
                 "iap-700000000097-continuation_preferences_2": "",
                 "iap-700000000097-continuation_preferences_3": "",
             },
         },
-    }
+    },
 }


### PR DESCRIPTION
# Purpose

Fix the config.py for tests.

Fixes UML-3091

## Approach

Currently, iap-700000000096-instructions and iap-700000000097-instructions aren't in the config.py resulting in them never being deleted. This causes these LPAs causes them to be always stuck in COLLECTION_COMPLETE for subsequent integration test runs.

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
