### PR TITLE
Split out dockerfile updates in renovate to avoid python issues

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,18 @@
         "after 6am and before 9am on Monday"
       ],
       "stabilityDays": 3
+    },
+    {
+      "description": "Docker file updates",
+      "automerge": false,
+      "groupName": "minor and patch updates (Docker)",
+      "groupSlug": "all-minor-patch-updates-python",
+      "labels": ["Dependencies", "Renovate"],
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
     }
   ],
   "major": {

--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
       "description": "Docker file updates",
       "automerge": false,
       "groupName": "minor and patch updates (Docker)",
-      "groupSlug": "all-minor-patch-updates-python",
+      "groupSlug": "all-minor-patch-updates-docker",
       "labels": ["Dependencies", "Renovate"],
       "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
We have some python version dependent files so bundling docker updates that bring in python version 3.12 docker files causes issues.