### PR TITLE
UML-3199 go to COLLECTION_ERROR if we fail to scan continuation sheets we were expecting

### DIFF
--- a/.github/workflows/sub-task-integration-tests.yml
+++ b/.github/workflows/sub-task-integration-tests.yml
@@ -16,7 +16,7 @@ on:
         required: true
 
 jobs:
-  terraform_workflow:
+  integration_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/integration/config.py
+++ b/integration/config.py
@@ -277,7 +277,7 @@ templates = {
             "status": "COLLECTION_IN_PROGRESS",
             "signedUrls": {},
         },
-        "expected_collection_error_response": {
+        "expected_collection_completed_response": {
             "uId": "700000000098",
             "status": "COLLECTION_ERROR",
             "signedUrls": {},

--- a/integration/config.py
+++ b/integration/config.py
@@ -32,6 +32,8 @@ templates = {
             "signedUrls": {
                 "iap-700000000047-instructions": "",
                 "iap-700000000047-preferences": "",
+                "iap-700000000047-continuation_instructions_1": "",
+                "iap-700000000047-continuation_preferences_1": "",
             },
         },
     },
@@ -261,6 +263,24 @@ templates = {
                 "iap-700000000093-continuation_instructions_1": "",
                 "iap-700000000093-continuation_preferences_1": "",
             },
+        },
+    },
+    "LP1F-tiff-file-continuation-wont-scan": {
+        "lpa_uid": "700000000098",
+        "expected_collection_started_response": {
+            "uId": "700000000098",
+            "status": "COLLECTION_NOT_STARTED",
+            "signedUrls": {},
+        },
+        "expected_collection_in_progress_response": {
+            "uId": "700000000098",
+            "status": "COLLECTION_IN_PROGRESS",
+            "signedUrls": {},
+        },
+        "expected_collection_in_progress_response": {
+            "uId": "700000000098",
+            "status": "COLLECTION_ERROR",
+            "signedUrls": {},
         },
     },
 }

--- a/integration/config.py
+++ b/integration/config.py
@@ -265,7 +265,7 @@ templates = {
             },
         },
     },
-    "LP1F-tiff-file-continuation-wont-scan": {
+    "LP1H-continuation-checked-but-no-continuation-images": {
         "lpa_uid": "700000000098",
         "expected_collection_started_response": {
             "uId": "700000000098",
@@ -277,7 +277,7 @@ templates = {
             "status": "COLLECTION_IN_PROGRESS",
             "signedUrls": {},
         },
-        "expected_collection_in_progress_response": {
+        "expected_collection_error_response": {
             "uId": "700000000098",
             "status": "COLLECTION_ERROR",
             "signedUrls": {},

--- a/integration/config.py
+++ b/integration/config.py
@@ -265,22 +265,23 @@ templates = {
             },
         },
     },
-    "LP1H-continuation-checked-but-no-continuation-images": {
-        "lpa_uid": "700000000098",
-        "expected_collection_started_response": {
-            "uId": "700000000098",
-            "status": "COLLECTION_NOT_STARTED",
-            "signedUrls": {},
-        },
-        "expected_collection_in_progress_response": {
-            "uId": "700000000098",
-            "status": "COLLECTION_IN_PROGRESS",
-            "signedUrls": {},
-        },
-        "expected_collection_completed_response": {
-            "uId": "700000000098",
-            "status": "COLLECTION_ERROR",
-            "signedUrls": {},
-        },
-    },
+    # TODO once UML-3201 and UML-3202 are done, we will switch on the throwing of an error, and so need to uncomment this
+    # "LP1H-continuation-checked-but-no-continuation-images": {
+    #     "lpa_uid": "700000000098",
+    #     "expected_collection_started_response": {
+    #         "uId": "700000000098",
+    #         "status": "COLLECTION_NOT_STARTED",
+    #         "signedUrls": {},
+    #     },
+    #     "expected_collection_in_progress_response": {
+    #         "uId": "700000000098",
+    #         "status": "COLLECTION_IN_PROGRESS",
+    #         "signedUrls": {},
+    #     },
+    #     "expected_collection_completed_response": {
+    #         "uId": "700000000098",
+    #         "status": "COLLECTION_ERROR",
+    #         "signedUrls": {},
+    #     },
+    # },
 }

--- a/integration/test_end_to_end.py
+++ b/integration/test_end_to_end.py
@@ -38,6 +38,7 @@ def cleanup_iap_buckets() -> list:
             "expected_collection_started_response",
             "expected_collection_in_progress_response",
             "expected_collection_completed_response",
+            "expected_collection_error_response",
         ]:
             collection = template_data[collection_type]
             signed_urls = collection["signedUrls"]
@@ -212,4 +213,16 @@ def test_collection_completed(setup_rest_url_part):
         time_remaining -= 30
     make_calls_and_assertions(
         "expected_collection_completed_response", setup_rest_url_part
+    )
+
+@pytest.mark.order(4)
+def test_collection_error(setup_rest_url_part):
+    time_remaining = 15 * 60  # countdown from 15 mins, tests should complete in this time
+
+    while time_remaining > 0:
+        print(f"Time remaining: {time_remaining} seconds")
+        time.sleep(30)  # sleep for 30 seconds
+        time_remaining -= 30
+    make_calls_and_assertions(
+        "expected_collection_error_response", setup_rest_url_part
     )

--- a/integration/test_end_to_end.py
+++ b/integration/test_end_to_end.py
@@ -213,15 +213,3 @@ def test_collection_completed(setup_rest_url_part):
     make_calls_and_assertions(
         "expected_collection_completed_response", setup_rest_url_part
     )
-
-@pytest.mark.order(4)
-def test_collection_error(setup_rest_url_part):
-    time_remaining = 15 * 60  # countdown from 15 mins, tests should complete in this time
-
-    while time_remaining > 0:
-        print(f"Time remaining: {time_remaining} seconds")
-        time.sleep(30)  # sleep for 30 seconds
-        time_remaining -= 30
-    make_calls_and_assertions(
-        "expected_collection_completed_response", setup_rest_url_part
-    )

--- a/integration/test_end_to_end.py
+++ b/integration/test_end_to_end.py
@@ -38,7 +38,6 @@ def cleanup_iap_buckets() -> list:
             "expected_collection_started_response",
             "expected_collection_in_progress_response",
             "expected_collection_completed_response",
-            "expected_collection_error_response",
         ]:
             collection = template_data[collection_type]
             signed_urls = collection["signedUrls"]
@@ -224,5 +223,5 @@ def test_collection_error(setup_rest_url_part):
         time.sleep(30)  # sleep for 30 seconds
         time_remaining -= 30
     make_calls_and_assertions(
-        "expected_collection_error_response", setup_rest_url_part
+        "expected_collection_completed_response", setup_rest_url_part
     )

--- a/lambdas/image_processor/app/utility/path_selection_service.py
+++ b/lambdas/image_processor/app/utility/path_selection_service.py
@@ -65,7 +65,9 @@ class PathSelectionService:
         logger.debug(f"Continuation sheet type: {continuation_sheet_type}")
 
         if not self.check_continuation_sheets_match_expected(continuation_sheets, continuation_sheet_type):
-           raise Exception("Images extracted from Continuation Sheets do not match what is expected based on the checkbox")
+            logger.warning("Images extracted from Continuation Sheets do not match what is expected based on the checkbox")
+           # The following line can be uncommented once UML-3201 and UML-3202 are done. For now we only log not error
+           #raise Exception("Images extracted from Continuation Sheets do not match what is expected based on the checkbox")
 
         # Created the final combined object of instructions, preferences and continuation sheets
         path_selection = self.merge_continuation_images_into_path_selection(

--- a/lambdas/image_processor/app/utility/path_selection_service.py
+++ b/lambdas/image_processor/app/utility/path_selection_service.py
@@ -62,6 +62,10 @@ class PathSelectionService:
                 paths, continuation_sheet_type, path_filter
             )
         logger.debug(f"List of Continuation sheets found: {continuation_sheets}")
+        logger.debug(f"Continuation sheet type: {continuation_sheet_type}")
+
+        if not self.check_continuation_sheets_match_expected(continuation_sheets, continuation_sheet_type):
+           raise Exception("Images extracted from Continuation Sheets do not match what is expected based on the checkbox")
 
         # Created the final combined object of instructions, preferences and continuation sheets
         path_selection = self.merge_continuation_images_into_path_selection(
@@ -69,6 +73,32 @@ class PathSelectionService:
         )
 
         return path_selection
+
+    @staticmethod
+    def check_continuation_sheets_match_expected(continuation_sheets, continuation_sheet_type):
+        logger.debug("check_continuation_sheets_match_expected called")
+        preferences_present = False
+        instructions_present = False
+        for continuation_sheet_key, continuation_sheet_values in continuation_sheets.items():
+            for continuation_page_key, continuation_page_value in continuation_sheet_values.items():
+                try:
+                    continuation_page_type = continuation_page_value['type']
+                    logger.debug(f"continuation page type is {continuation_page_type}")
+                    if continuation_page_type == "preferences":
+                        preferences_present = True
+                    if continuation_page_type == "instructions":
+                        instructions_present = True
+                except:
+                    continue
+
+        logger.debug("checking what we found against what we EXPECTED")
+        if continuation_sheet_type in ["PREFERENCES", "BOTH"] and not preferences_present:
+            return False
+
+        if continuation_sheet_type in ["INSTRUCTIONS", "BOTH"] and not instructions_present:
+            return False
+
+        return True
 
     def find_instruction_and_preference_paths(
         self, path_selection: dict, paths: list

--- a/lambdas/image_processor/tests/utility/path_selection_service_test.py
+++ b/lambdas/image_processor/tests/utility/path_selection_service_test.py
@@ -348,3 +348,112 @@ def test_detect_marked_checkbox(path_selection_service):
     assert (
         path_selection_service.detect_marked_checkbox(unmarked_checkbox_path) is False
     )
+
+
+def test_check_continuation_sheets_match_expected(path_selection_service):
+    continuation_sheets = {
+        "continuation_1": {
+            "p1": {
+                "path": "/tmp/output/pass/1702460388/continuation_1/run=1702460390/meta=lpc/field_name=continuation_sheet_p1/00_LPC-Scan.jpg",
+                "type": "instructions",
+            },
+            "p2": {
+                "path": "/tmp/output/pass/1702460388/continuation_1/run=1702460390/meta=lpc/field_name=continuation_sheet_p2/00_LPC-Scan.jpg",
+                "type": "preferences",
+            },
+        }
+    }
+
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "BOTH"
+        )
+        == True
+    )
+    # we allow there to be more than expected, that counts as a match too
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "PREFERENCES"
+        )
+        == True
+    )
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "INSTRUCTIONS"
+        )
+        == True
+    )
+
+    continuation_sheets = {
+        "continuation_1": {
+            "p1": {
+                "path": "/tmp/output/pass/1702460388/continuation_1/run=1702460390/meta=lpc/field_name=continuation_sheet_p1/00_LPC-Scan.jpg",
+                "type": "instructions",
+            }
+        }
+    }
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "BOTH"
+        )
+        == False
+    )
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "PREFERENCES"
+        )
+        == False
+    )
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "INSTRUCTIONS"
+        )
+        == True
+    )
+
+    continuation_sheets = {
+        "continuation_1": {
+            "p1": {
+                "path": "/tmp/output/pass/1702460388/continuation_1/run=1702460390/meta=lpc/field_name=continuation_sheet_p2/00_LPC-Scan.jpg",
+                "type": "preferences",
+            }
+        }
+    }
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "BOTH"
+        )
+        == False
+    )
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "PREFERENCES"
+        )
+        == True
+    )
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "INSTRUCTIONS"
+        )
+        == False
+    )
+
+    continuation_sheets = {}
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "BOTH"
+        )
+        == False
+    )
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "PREFERENCES"
+        )
+        == False
+    )
+    assert (
+        path_selection_service.check_continuation_sheets_match_expected(
+            continuation_sheets, "INSTRUCTIONS"
+        )
+        == False
+    )

--- a/mock-services/sirius/app/sirius-local.yml
+++ b/mock-services/sirius/app/sirius-local.yml
@@ -25,7 +25,7 @@ paths:
                 lpa0047:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LP1H-Scan.pdf', 'template': 'LP1H'}, {'location': 's3://opg-backoffice-datastore-local/LPA120.pdf', 'template': 'LPA'}]
-                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPC-LP-Scan.pdf', 'template': 'LPC'}]
+                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPC-Scan.pdf', 'template': 'LPC'}]
                 lpa0138:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LP1F-Scan.pdf', 'template': 'LP1F'}]

--- a/mock-services/sirius/app/sirius-local.yml
+++ b/mock-services/sirius/app/sirius-local.yml
@@ -25,6 +25,7 @@ paths:
                 lpa0047:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LP1H-Scan.pdf', 'template': 'LP1H'}, {'location': 's3://opg-backoffice-datastore-local/LPA120.pdf', 'template': 'LPA'}]
+                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPC-LP-Scan.pdf', 'template': 'LPC'}]
                 lpa0138:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LP1F-Scan.pdf', 'template': 'LP1F'}]

--- a/mock-services/sirius/app/sirius-local.yml
+++ b/mock-services/sirius/app/sirius-local.yml
@@ -71,7 +71,6 @@ paths:
                 lpa0098:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LP1H-Scan.pdf', 'template': 'LP1H'}, {'location': 's3://opg-backoffice-datastore-local/LPA120.pdf', 'template': 'LPA'}]
-                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPC-Scan.tiff', 'template': 'LPC'}]
               schema:
                 type: object
                 properties:

--- a/mock-services/sirius/app/sirius-local.yml
+++ b/mock-services/sirius/app/sirius-local.yml
@@ -68,7 +68,7 @@ paths:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LPA-prefs-only-plus-continuation-working-LP1F.pdf', 'template': ''}]
                     continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPA-prefs-only-plus-continuation-working-LP1F.pdf', 'template': 'LP1F'}]
-                lpa0047:
+                lpa0098:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LP1H-Scan.pdf', 'template': 'LP1H'}, {'location': 's3://opg-backoffice-datastore-local/LPA120.pdf', 'template': 'LPA'}]
                     continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPC-LP-Scan.tiff', 'template': 'LPC'}]

--- a/mock-services/sirius/app/sirius-local.yml
+++ b/mock-services/sirius/app/sirius-local.yml
@@ -71,7 +71,7 @@ paths:
                 lpa0098:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LP1H-Scan.pdf', 'template': 'LP1H'}, {'location': 's3://opg-backoffice-datastore-local/LPA120.pdf', 'template': 'LPA'}]
-                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPC-LP-Scan.tiff', 'template': 'LPC'}]
+                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPC-Scan.tiff', 'template': 'LPC'}]
               schema:
                 type: object
                 properties:

--- a/mock-services/sirius/app/sirius-local.yml
+++ b/mock-services/sirius/app/sirius-local.yml
@@ -68,6 +68,10 @@ paths:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LPA-prefs-only-plus-continuation-working-LP1F.pdf', 'template': ''}]
                     continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPA-prefs-only-plus-continuation-working-LP1F.pdf', 'template': 'LP1F'}]
+                lpa0047:
+                  value:
+                    lpaScans: [{'location': 's3://opg-backoffice-datastore-local/LP1H-Scan.pdf', 'template': 'LP1H'}, {'location': 's3://opg-backoffice-datastore-local/LPA120.pdf', 'template': 'LPA'}]
+                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-local/LPC-LP-Scan.tiff', 'template': 'LPC'}]
               schema:
                 type: object
                 properties:

--- a/mock-services/sirius/app/sirius.yml
+++ b/mock-services/sirius/app/sirius.yml
@@ -71,7 +71,6 @@ paths:
                 lpa0098:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-integration/LP1H-Scan.pdf', 'template': 'LP1H'}, { 'location': 's3://opg-backoffice-datastore-integration/LPA120.pdf', 'template': 'LPA'}]
-                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-integration/LPC-Scan.tiff', 'template': 'LPC'}]
               schema:
                 type: object
                 properties:

--- a/mock-services/sirius/app/sirius.yml
+++ b/mock-services/sirius/app/sirius.yml
@@ -25,6 +25,7 @@ paths:
                 lpa0047:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-integration/LP1H-Scan.pdf', 'template': 'LP1H'}, { 'location': 's3://opg-backoffice-datastore-integration/LPA120.pdf', 'template': 'LPA'}]
+                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-integration/LPC-Scan.pdf', 'template': 'LPC'}]
                 lpa0138:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-integration/LP1F-Scan.pdf', 'template': 'LP1F'}]

--- a/mock-services/sirius/app/sirius.yml
+++ b/mock-services/sirius/app/sirius.yml
@@ -68,6 +68,10 @@ paths:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-integration/LPA-prefs-only-plus-continuation-working-LP1F.pdf', 'template': ''}]
                     continuationSheets: [{'location': 's3://opg-backoffice-datastore-integration/LPA-prefs-only-plus-continuation-working-LP1F.pdf', 'template': 'LP1F'}]
+                lpa0098:
+                  value:
+                    lpaScans: [{'location': 's3://opg-backoffice-datastore-integration/LP1H-Scan.pdf', 'template': 'LP1H'}, { 'location': 's3://opg-backoffice-datastore-integration/LPA120.pdf', 'template': 'LPA'}]
+                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-integration/LPC-Scan.tiff', 'template': 'LPc'}]
               schema:
                 type: object
                 properties:

--- a/mock-services/sirius/app/sirius.yml
+++ b/mock-services/sirius/app/sirius.yml
@@ -71,7 +71,7 @@ paths:
                 lpa0098:
                   value:
                     lpaScans: [{'location': 's3://opg-backoffice-datastore-integration/LP1H-Scan.pdf', 'template': 'LP1H'}, { 'location': 's3://opg-backoffice-datastore-integration/LPA120.pdf', 'template': 'LPA'}]
-                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-integration/LPC-Scan.tiff', 'template': 'LPc'}]
+                    continuationSheets: [{'location': 's3://opg-backoffice-datastore-integration/LPC-Scan.tiff', 'template': 'LPC'}]
               schema:
                 type: object
                 properties:

--- a/mock-services/sirius/web/nginx-local.conf
+++ b/mock-services/sirius/web/nginx-local.conf
@@ -15,7 +15,7 @@ map $request_uri $swagger_example {
     "~^/v1/lpas/700000000095/scans$" "lpa0095";
     "~^/v1/lpas/700000000096/scans$" "lpa0096";
     "~^/v1/lpas/700000000097/scans$" "lpa0097";
-    "~^/v1/lpas/700000000097/scans$" "lpa0098";
+    "~^/v1/lpas/700000000098/scans$" "lpa0098";
     default                         "NOTFOUND";
 }
 

--- a/mock-services/sirius/web/nginx-local.conf
+++ b/mock-services/sirius/web/nginx-local.conf
@@ -15,6 +15,7 @@ map $request_uri $swagger_example {
     "~^/v1/lpas/700000000095/scans$" "lpa0095";
     "~^/v1/lpas/700000000096/scans$" "lpa0096";
     "~^/v1/lpas/700000000097/scans$" "lpa0097";
+    "~^/v1/lpas/700000000097/scans$" "lpa0098";
     default                         "NOTFOUND";
 }
 

--- a/mock-services/sirius/web/nginx.conf
+++ b/mock-services/sirius/web/nginx.conf
@@ -15,6 +15,7 @@ map $request_uri $swagger_example {
     "~^/api/public/v1/lpas/700000000095/scans$" "lpa0095";
     "~^/api/public/v1/lpas/700000000096/scans$" "lpa0096";
     "~^/api/public/v1/lpas/700000000097/scans$" "lpa0097";
+    "~^/api/public/v1/lpas/700000000097/scans$" "lpa0098";
     default                                     "NOTFOUND";
 }
 

--- a/mock-services/sirius/web/nginx.conf
+++ b/mock-services/sirius/web/nginx.conf
@@ -15,7 +15,7 @@ map $request_uri $swagger_example {
     "~^/api/public/v1/lpas/700000000095/scans$" "lpa0095";
     "~^/api/public/v1/lpas/700000000096/scans$" "lpa0096";
     "~^/api/public/v1/lpas/700000000097/scans$" "lpa0097";
-    "~^/api/public/v1/lpas/700000000097/scans$" "lpa0098";
+    "~^/api/public/v1/lpas/700000000098/scans$" "lpa0098";
     default                                     "NOTFOUND";
 }
 


### PR DESCRIPTION
# Purpose

_This is a bug fix. Currently, its possible for a LPA to have the boxes checked to indicate there are further instructions and/or preferences on continuation sheet(s), but in a minority of cases the system may fail to read these sheets, and not make the user aware. This change takes us to COLLECTION_ERROR if this happens, so a user doesn't get the false impression they have all the instructions and preferences they need, when there's extra info on continuation sheets which we failed to load an image for._

## Approach

_Extra logic in the image processor. Added continuation sheets for lpa0047 in mock , as this would now error out otherwise. Added lpa0098 which should error out due to lack of continuation sheets. Modified tests to also test for collection_error_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
