### PR TITLE
UML-3216: Allow execute-api for operator

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -24,7 +24,9 @@
       "force_destroy_bucket": false,
       "is_production": false,
       "opg_hosted_zone": "pre.lpa-iap.api.opg.service.justice.gov.uk",
-      "extra_allowed_roles": [],
+      "extra_allowed_roles": [
+        "arn:aws:iam::492687888235:operator"
+      ],
       "vpc_id": "vpc-037acd53d9ce813b4",
       "target_environment": "preproduction",
       "secret_prefix": "preproduction",
@@ -37,7 +39,9 @@
       "force_destroy_bucket": false,
       "is_production": true,
       "opg_hosted_zone": "lpa-iap.api.opg.service.justice.gov.uk",
-      "extra_allowed_roles": [],
+      "extra_allowed_roles": [
+        "arn:aws:iam::132068124730:operator"
+      ],
       "vpc_id": "vpc-6809cc0f",
       "target_environment": "production",
       "secret_prefix": "production",


### PR DESCRIPTION
# Purpose

Allow execute-api:Invoke for operator role to allow operators to rerun an image scan.

Fixes UML-3216

## Approach


## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
