### PR TITLE
UML-2763 Allow CloudWatch to publish to alarm SNS topic

### DIFF
--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -146,7 +146,7 @@ data "aws_iam_policy_document" "sns_kms" {
     effect    = "Allow"
     resources = ["*"]
     actions = [
-      "kms:Encrypt",
+      "kms:Decrypt",
       "kms:GenerateDataKey*",
     ]
 

--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -142,6 +142,23 @@ data "aws_iam_policy_document" "sns_kms" {
   }
 
   statement {
+    sid       = "Allow Key to be used for Encryption by CloudWatch"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "cloudwatch.amazonaws.com",
+      ]
+    }
+  }
+
+  statement {
     sid       = "Key Administrator"
     effect    = "Allow"
     resources = ["*"]

--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -19,3 +19,26 @@ resource "pagerduty_service_integration" "cloudwatch_integration" {
   service = local.account.pagerduty_service_id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
+
+resource "aws_sns_topic_policy" "cloudwatch_to_pagerduty" {
+  arn    = aws_sns_topic.cloudwatch_to_pagerduty.arn
+  policy = data.aws_iam_policy_document.cloudwatch_to_pagerduty.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_to_pagerduty" {
+  statement {
+    sid = "AllowCloudWatchToPublishToSNS"
+    actions = [
+      "sns:Publish",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+
+    resources = [
+      aws_sns_topic.cloudwatch_to_pagerduty.arn,
+    ]
+  }
+}


### PR DESCRIPTION
# Purpose

Allow CloudWatch to publish to the alarm SNS topic so that alarms can be send to PagerDuty

Fixes UML-2763

## Approach

_Explain how your code addresses the purpose of the change._

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
