### PR TITLE
reduce concurrent renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,5 +82,6 @@
     "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
     "prCreation": "immediate",
     "prPriority": 5
-  }
+  },
+  "prConcurrentLimit": 1
 }


### PR DESCRIPTION
# Purpose

_Renovate is currently creating PRs in parallel. These tend to trample on each other with terraform locks, especially when they auto-rebuild when main gets updated. For now we should only allow 1 at a time until we have a better way._

## Approach

_Update renovate config._

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
