### PR TITLE
Stop downgrading npm

### DIFF
--- a/mock-services/sirius/app/Dockerfile
+++ b/mock-services/sirius/app/Dockerfile
@@ -1,7 +1,6 @@
 FROM stoplight/prism:5.14.2
 COPY sirius.yml run.sh /app/
 RUN apk upgrade libcrypto1.1 libssl3 busybox ssl_client zlib
-RUN npm -g install npm@8.19.4
 WORKDIR  /app
 RUN chmod +x run.sh
 ENTRYPOINT ["/app/run.sh"]


### PR DESCRIPTION
Use version included in stoplight/prism image (currently 10.8.2)
