### PR TITLE
Add demo environment

### DIFF
--- a/.github/workflows/workflow-path-to-live.yml
+++ b/.github/workflows/workflow-path-to-live.yml
@@ -181,9 +181,23 @@ jobs:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
+  demo_environment_plan_apply:
+    name: Demo Environment Terraform Plan and Apply
+    needs: [
+      'production_environment_plan_apply'
+    ]
+    uses: ./.github/workflows/sub-task-terraform.yml
+    with:
+      terraform_path: 'terraform/environment'
+      image_tag: main-${{ needs.create_tags.outputs.version_tag }}
+      workspace: demo
+    secrets:
+      aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+
   workflow_complete:
     name: Workflow Complete
-    needs: ['production_environment_plan_apply']
+    needs: ['production_environment_plan_apply', 'demo_environment_plan_apply']
     runs-on: ubuntu-latest
     steps:
       - name: Completion message

--- a/terraform/environment/.envrc
+++ b/terraform/environment/.envrc
@@ -1,5 +1,6 @@
 export TF_CLI_ARGS_init="-backend-config=role_arn=arn:aws:iam::311462405659:role/operator -upgrade -reconfigure"
-export TF_WORKSPACE=development
+export TF_WORKSPACE=demo
 export TF_VAR_management_role=operator
 export TF_VAR_default_role=operator
 export TF_VAR_pagerduty_token=$(aws-vault exec sirius-dev-operator -- aws secretsmanager get-secret-value --secret-id iap_pagerduty_api_key | jq -r .'SecretString')
+export TF_VAR_image_tag=v0.305.0

--- a/terraform/environment/iam.tf
+++ b/terraform/environment/iam.tf
@@ -63,7 +63,7 @@ resource "aws_iam_role_policy_attachment" "ual_iap_processor_lambda_attachment" 
 }
 
 data "aws_s3_bucket" "sirius" {
-  bucket = "opg-backoffice-datastore-${local.account.target_environment}"
+  bucket = "opg-backoffice-datastore-${local.target_environment}"
 }
 
 data "aws_kms_key" "secrets_manager" {

--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -31,9 +31,9 @@ module "processor_lamdba" {
   lambda_name = "lpa-iap-processor-${local.environment}"
   environment_variables = {
     ENVIRONMENT        = local.environment
-    SIRIUS_URL         = var.use_mock_sirius ? "http://mock-sirius.lpa-iap-${local.environment}.ecs" : "http://api.${local.account.target_environment}.ecs"
+    SIRIUS_URL         = var.use_mock_sirius ? "http://mock-sirius.lpa-iap-${local.environment}.ecs" : "http://api.${local.target_environment}.ecs"
     SESSION_DATA       = local.session_data
-    TARGET_ENVIRONMENT = local.account.target_environment
+    TARGET_ENVIRONMENT = local.target_environment
     SECRET_PREFIX      = local.account.secret_prefix
     SIRIUS_URL_PART    = "/api/public/v1"
     LOGGER_LEVEL       = "INFO"
@@ -54,6 +54,6 @@ module "processor_lamdba" {
 data "aws_security_group" "lambda_api_ingress" {
   filter {
     name   = "tag:Name"
-    values = ["integration-lambda-api-access-${local.account.target_environment}"]
+    values = ["integration-lambda-api-access-${local.target_environment}"]
   }
 }

--- a/terraform/environment/mock_sirius.tf
+++ b/terraform/environment/mock_sirius.tf
@@ -6,7 +6,7 @@ module "mock_sirius" {
   use_mock_sirius     = var.use_mock_sirius
   subnets             = data.aws_subnets.private.ids
   image_tag           = var.image_tag
-  target_environment  = local.account.target_environment
+  target_environment  = local.target_environment
   s3_vpc_endpoint_ids = local.account.s3_vpc_endpoint_ids
   providers = {
     aws            = aws,

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -14,7 +14,6 @@
         "arn:aws:iam::288342028542:role/synthetics-dev"
       ],
       "vpc_id": "vpc-faf2d99e",
-      "target_environment": "integration",
       "secret_prefix": "development",
       "s3_vpc_endpoint_ids": ["vpce-0d1a2425df0aae7a6", "vpce-09df36318c738f067", "vpce-0030596e5f51e6271"]
     },
@@ -31,7 +30,6 @@
         "arn:aws:iam::492687888235:role/synthetics-preproduction"
       ],
       "vpc_id": "vpc-037acd53d9ce813b4",
-      "target_environment": "preproduction",
       "secret_prefix": "preproduction",
       "s3_vpc_endpoint_ids": ["vpce-07c8b9bc931b5d915", "vpce-0b4969d793365d5d4", "vpce-0ae35d9cfc690bc1d"]
     },
@@ -48,9 +46,14 @@
         "arn:aws:iam::649098267436:role/synthetics-production"
       ],
       "vpc_id": "vpc-6809cc0f",
-      "target_environment": "production",
       "secret_prefix": "production",
       "s3_vpc_endpoint_ids": ["vpce-0b11fce9ccf477cc4", "vpce-057ab47f904b98293", "vpce-00c27012a29d47f82"]
     }
+  },
+  "environment_mapping": {
+    "default": "integration",
+    "demo": "demo",
+    "preproduction": "preproduction",
+    "production": "production"
   }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -1,9 +1,10 @@
 locals {
-  environment       = terraform.workspace
-  account           = contains(keys(var.accounts), local.environment) ? var.accounts[local.environment] : var.accounts.development
-  branch_build_flag = contains(keys(var.accounts), local.environment) ? false : true
-  a_record          = local.branch_build_flag ? "${local.environment}.${data.aws_route53_zone.environment_cert.name}" : data.aws_route53_zone.environment_cert.name
-  api_name          = "image-request-handler"
+  environment        = terraform.workspace
+  account            = contains(keys(var.accounts), local.environment) ? var.accounts[local.environment] : var.accounts.development
+  branch_build_flag  = contains(keys(var.accounts), local.environment) ? false : true
+  a_record           = local.branch_build_flag ? "${local.environment}.${data.aws_route53_zone.environment_cert.name}" : data.aws_route53_zone.environment_cert.name
+  api_name           = "image-request-handler"
+  target_environment = contains(keys(var.environment_mapping), local.environment) ? var.environment_mapping[local.environment] : var.environment_mapping.default
 
   expiration_days            = 365
   noncurrent_expiration_days = 30
@@ -57,10 +58,13 @@ variable "accounts" {
       opg_hosted_zone      = string
       extra_allowed_roles  = list(string)
       vpc_id               = string
-      target_environment   = string
       secret_prefix        = string
       s3_vpc_endpoint_ids  = set(string)
     })
   )
   description = "A map of accounts to deploy to"
+}
+
+variable "environment_mapping" {
+  type = map(string)
 }


### PR DESCRIPTION
## Purpose

Set up configuration and add deployment step to pipeline

Fixes SP-2853 #patch

## Approach

I've taken the same approach as [opg-data-lpa](https://github.com/ministryofjustice/opg-data-lpa/pull/230), to separate the environment mapping from the account configuration. This allows us to have multiple envs in the same account.
