### PR TITLE
Fix demo deployment config

### DIFF
--- a/.github/workflows/workflow-path-to-live.yml
+++ b/.github/workflows/workflow-path-to-live.yml
@@ -184,7 +184,8 @@ jobs:
   demo_environment_plan_apply:
     name: Demo Environment Terraform Plan and Apply
     needs: [
-      'production_environment_plan_apply'
+      'production_environment_plan_apply',
+      'create_tags'
     ]
     uses: ./.github/workflows/sub-task-terraform.yml
     with:


### PR DESCRIPTION
We need to mark `create_tags` as a dependency step so that we can pass the version_tag to Terraform.

For SP-2853 #patch
