### PR TITLE
UML-4266 Use the file size instead of metadata to allow batching

### DIFF
--- a/lambdas/delete_failed_images/main.go
+++ b/lambdas/delete_failed_images/main.go
@@ -4,8 +4,8 @@
 // iterate over. By default it will log the images that it would delete, call
 // with body `{"Delete": true}` to actually delete them.
 //
-// Will continue if an error occurs when trying to retrieve an object's metadata
-// or delete an object, logging the error for later inspection.
+// Will continue if an error occurs when trying to delete objects, logging the
+// errors for later inspection.
 package main
 
 import (
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 var (
@@ -79,30 +80,38 @@ func processBucket(ctx context.Context, s3Client *s3.Client, bucketName string, 
 			return err
 		}
 
+		var toDelete []types.ObjectIdentifier
+
 		for _, object := range output.Contents {
-			meta, err := s3Client.HeadObject(ctx, &s3.HeadObjectInput{
+			if *object.Size == 0 {
+				toDelete = append(toDelete, types.ObjectIdentifier{Key: object.Key})
+			}
+		}
+
+		if doDelete {
+			out, err := s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
 				Bucket: new(bucketName),
-				Key:    object.Key,
+				Delete: &types.Delete{
+					Objects: toDelete,
+				},
 			})
 			if err != nil {
-				slog.Error("head object", slog.String("key", *object.Key), slog.String("err", err.Error()))
+				for _, object := range toDelete {
+					slog.Error("error deleting object", slog.String("key", *object.Key), slog.String("err", err.Error()))
+				}
 				continue
 			}
 
-			if meta.Metadata["processerror"] == "1" {
-				if doDelete {
-					_, err := s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
-						Bucket: new(bucketName),
-						Key:    object.Key,
-					})
-					if err != nil {
-						slog.Error("delete object", slog.String("key", *object.Key), slog.String("err", err.Error()))
-						continue
-					}
-					slog.Info("deleted", slog.String("key", *object.Key))
-				} else {
-					slog.Info("should delete", slog.String("key", *object.Key))
-				}
+			for _, error := range out.Errors {
+				slog.Info("error deleting object", slog.String("key", *error.Key), slog.String("msg", *error.Message))
+			}
+
+			for _, object := range out.Deleted {
+				slog.Info("deleted", slog.String("key", *object.Key))
+			}
+		} else {
+			for _, object := range toDelete {
+				slog.Info("should delete", slog.String("key", *object.Key))
 			}
 		}
 	}

--- a/lambdas/delete_failed_images/main_test.go
+++ b/lambdas/delete_failed_images/main_test.go
@@ -85,19 +85,16 @@ func TestDryRun(t *testing.T) {
 
 	slog.SetDefault(slog.New(slog.DiscardHandler))
 
-	for key, processerror := range map[string]string{
-		"good-instructions.jpg": "",
-		"good-preferences.jpg":  "",
-		"bad-instructions.jpg":  "1",
-		"bad-preferences.jpg":   "1",
+	for key, body := range map[string]string{
+		"good-instructions.jpg": "hey",
+		"good-preferences.jpg":  "hey",
+		"bad-instructions.jpg":  "",
+		"bad-preferences.jpg":   "",
 	} {
 		if _, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
 			Bucket: new(bucketName),
 			Key:    new(key),
-			Body:   strings.NewReader("hey"),
-			Metadata: map[string]string{
-				"processerror": processerror,
-			},
+			Body:   strings.NewReader(body),
 		}); err != nil {
 			t.Fatalf("put object: %v", err)
 		}
@@ -143,17 +140,11 @@ func TestRun(t *testing.T) {
 
 	slog.SetDefault(slog.New(slog.DiscardHandler))
 
-	for key, processerror := range map[string]string{
-		"good-instructions.jpg": "",
-		"good-preferences.jpg":  "",
-	} {
+	for _, key := range []string{"good-instructions.jpg", "good-preferences.jpg"} {
 		if _, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
 			Bucket: new(bucketName),
 			Key:    new(key),
 			Body:   strings.NewReader("hey"),
-			Metadata: map[string]string{
-				"processerror": processerror,
-			},
 		}); err != nil {
 			t.Fatalf("put object: %v", err)
 		}
@@ -163,10 +154,7 @@ func TestRun(t *testing.T) {
 		if _, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
 			Bucket: new(bucketName),
 			Key:    new(fmt.Sprintf("bad-%d.jpg", i)),
-			Body:   strings.NewReader("hey"),
-			Metadata: map[string]string{
-				"processerror": "1",
-			},
+			Body:   strings.NewReader(""),
 		}); err != nil {
 			t.Fatalf("put object: %v", err)
 		}


### PR DESCRIPTION
The previous version was too slow. Since the metadata isn't needed, as the files we want to delete are all empty, I don't need to iterate over each object.