### PR TITLE
Revert "UML-4384 - Turn on I&P IP restrictions in prod"

### DIFF
--- a/terraform/environment/api_rest.tf
+++ b/terraform/environment/api_rest.tf
@@ -62,5 +62,5 @@ locals {
       module.allow_list.sirius_prod_allow_list,
     )
   }
-  ip_restrictions_enabled = contains(["preproduction", "production"], local.account.name)
+  ip_restrictions_enabled = contains(["preproduction"], local.account.name)
 }


### PR DESCRIPTION
Reverts ministryofjustice/opg-data-lpa-instructions-preferences#470

local image extractions don't work with the IP restrictions in place, will need an alternative solution for this.