### PR TITLE
UML-4429 When 'template' is not specified try extracting against all

### DIFF
--- a/lambdas/image_processor/app/utility/bucket_manager.py
+++ b/lambdas/image_processor/app/utility/bucket_manager.py
@@ -1,5 +1,4 @@
 import os
-import re
 import boto3
 from app.utility.custom_logging import custom_logger
 
@@ -18,15 +17,6 @@ class ScanLocation:
     @property
     def location(self) -> str:
         return self.__location
-
-    @property
-    def redacted_location(self) -> str:
-        redacted_file_path = re.sub(
-            r"(.*/[a-f0-9]{,13}_).*(\.\w{3,4})$",
-            r"\1****\2",
-            self.__location
-        )
-        return redacted_file_path
 
     def set_location(self, location):
         self.__location = location
@@ -137,10 +127,6 @@ class BucketManager:
             scan_location = ScanLocation(
                 location=lpa_scan["location"], template=lpa_scan.get("template")
             )
-
-            if scan_location.template is None:
-                logger.error(f"{self.request_id} Error adding scan location: {scan_location.redacted_location}")
-                continue
 
             lpa_locations.append(scan_location)
             self.info_msg.document_templates.append(scan_location.template)

--- a/lambdas/image_processor/app/utility/bucket_manager.py
+++ b/lambdas/image_processor/app/utility/bucket_manager.py
@@ -128,6 +128,9 @@ class BucketManager:
                 location=lpa_scan["location"], template=lpa_scan.get("template")
             )
 
+            if not scan_location.location.lower().endswith((".pdf", ".tiff", ".tif")):
+                continue
+
             lpa_locations.append(scan_location)
             self.info_msg.document_templates.append(scan_location.template)
 

--- a/lambdas/image_processor/tests/utility/bucket_manager_test.py
+++ b/lambdas/image_processor/tests/utility/bucket_manager_test.py
@@ -51,10 +51,14 @@ def test_download_scanned_images(bucket_manager, monkeypatch):
     s3_urls_dict = {
         "lpaScans": [
             {
-                "location": "s3://my_bucket/5fbcd594bac0e_my_scan.pdf", "template": "TEST"
+                "location": "s3://my_bucket/5fbcd594bac0e_my_scan.pdf",
+                "template": "TEST",
             },
             {
                 "location": "s3://my_bucket/5a980ebab6ae2_additional - correspondence.msg",
+            },
+            {
+                "location": "s3://my_bucket/5a980ebab6ae2_00001.pdf",
             },
         ],
         "continuationSheets": [
@@ -81,12 +85,14 @@ def test_download_scanned_images(bucket_manager, monkeypatch):
     # Check that the expected S3 files were downloaded
     assert len(mock_download_file.mock_calls) == 4
     mock_download_file.assert_any_call(
-        "my_bucket", "5fbcd594bac0e_my_scan.pdf", "/tmp/output/5fbcd594bac0e_my_scan.pdf"
+        "my_bucket",
+        "5fbcd594bac0e_my_scan.pdf",
+        "/tmp/output/5fbcd594bac0e_my_scan.pdf",
     )
     mock_download_file.assert_any_call(
         "my_bucket",
-        "5a980ebab6ae2_additional - correspondence.msg",
-        "/tmp/output/5a980ebab6ae2_additional - correspondence.msg",
+        "5a980ebab6ae2_00001.pdf",
+        "/tmp/output/5a980ebab6ae2_00001.pdf",
     )
     mock_download_file.assert_any_call(
         "my_bucket",

--- a/lambdas/image_processor/tests/utility/bucket_manager_test.py
+++ b/lambdas/image_processor/tests/utility/bucket_manager_test.py
@@ -79,9 +79,14 @@ def test_download_scanned_images(bucket_manager, monkeypatch):
     result = bucket_manager.download_scanned_images(s3_urls_dict, output_folder_path)
 
     # Check that the expected S3 files were downloaded
-    assert len(mock_download_file.mock_calls) == 3
+    assert len(mock_download_file.mock_calls) == 4
     mock_download_file.assert_any_call(
         "my_bucket", "5fbcd594bac0e_my_scan.pdf", "/tmp/output/5fbcd594bac0e_my_scan.pdf"
+    )
+    mock_download_file.assert_any_call(
+        "my_bucket",
+        "5a980ebab6ae2_additional - correspondence.msg",
+        "/tmp/output/5a980ebab6ae2_additional - correspondence.msg",
     )
     mock_download_file.assert_any_call(
         "my_bucket",
@@ -96,7 +101,10 @@ def test_download_scanned_images(bucket_manager, monkeypatch):
 
     # Check that the function returned the expected file paths
     expected_result = {
-        "scans": [{"location": "/tmp/output/5fbcd594bac0e_my_scan.pdf", "template": "TEST"}],
+        "scans": [
+            {"location": "/tmp/output/5fbcd594bac0e_my_scan.pdf", "template": "TEST"},
+            {"location": "/tmp/output/5a980ebab6ae2_additional - correspondence.msg", "template": None},
+        ],
         "continuations": {
             "continuation_1": {
                 "location": "/tmp/output/my_continuation_sheet1.pdf",


### PR DESCRIPTION
I don't like this behaviour, but it is what was happening in 2024...

Sirius [used to return `"template": null` in responses](https://github.com/ministryofjustice/opg-sirius/blob/cdbd20f990a6e9828381659a4847891edcd26b2d/back-end/module/Application/src/Controller/PublicApi/V1/LpaController.php#L135). At some point the serialisation behaviour was changed to remove `null`s from the response. That then caused the old "template error" we had. The change we then made to skip these was based on the assumption that this was what should be done, but reading the old code shows that actually the behaviour was to try against all templates if not provided.