### PR TITLE
upgrade pyJWT

### DIFF
--- a/lambdas/image_processor/requirements.in
+++ b/lambdas/image_processor/requirements.in
@@ -15,7 +15,7 @@ opencv-python==4.13.0.92
 pdf2image==1.17.0
 pdfminer-six==20251230
 pydantic==1.10.26
-pyjwt==2.12.1
+pyjwt==2.13.0
 pyopengl==3.1.10
 pypdf==6.10.2
 pytesseract==0.3.13

--- a/lambdas/image_processor/requirements.txt
+++ b/lambdas/image_processor/requirements.txt
@@ -115,7 +115,7 @@ pycparser==3.0
     # via cffi
 pydantic==1.10.26
     # via -r requirements.in
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via -r requirements.in
 pyopengl==3.1.10
     # via -r requirements.in


### PR DESCRIPTION
# Purpose

Upgrades PyJWT from 2.12.1 to >=2.13.0 to address Dependabot advisory GHSA-75c5-xw7c-p5pm

Fixes security alert

## Approach

Current usage in image_processor appears limited to JWT generation (jwt.encode) and test decoding using a fixed HS256 secret, so exploitability is low. The dependency has been upgraded to remove the vulnerable version and satisfy Dependabot.

## Learning

Currently the repo has pyjwt==2.12.1. Dependabot reports repo is on a vulnerable version.
My understanding [from the code base search] is Lambda is only creating JWTs, not verifying them.

This means the vulnerability non-exploitable in application because the vulnerable code path is in verification.
Regardless applying the upgrade.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
