### PR TITLE
Upgrade pypdf to fix 8 Dependabot alerts

### DIFF
--- a/lambdas/image_processor/requirements.in
+++ b/lambdas/image_processor/requirements.in
@@ -17,7 +17,7 @@ pdfminer-six==20251230
 pydantic==1.10.26
 pyjwt==2.13.0
 pyopengl==3.1.10
-pypdf==6.10.2
+pypdf==6.13.3
 pytesseract==0.3.13
 pyzbar==0.1.9
 requests==2.33.0

--- a/lambdas/image_processor/requirements.txt
+++ b/lambdas/image_processor/requirements.txt
@@ -119,7 +119,7 @@ pyjwt==2.13.0
     # via -r requirements.in
 pyopengl==3.1.10
     # via -r requirements.in
-pypdf==6.10.2
+pypdf==6.13.3
     # via -r requirements.in
 pytesseract==0.3.13
     # via -r requirements.in


### PR DESCRIPTION
# Purpose

Upgrade pypdf to fix [8 Dependabot alerts](

Fixes pdf related vulnerabilities

## Approach

No major version change, upgrading pypdf from 6.10.2 to 6.13.3.
The upgrade is specifically the version recommended by the security advisory.
pypdf maintains reasonable backwards compatibility within a major release.

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
