### PR TITLE
Ignoe_CVEs: There is no fixed version for Debian:13 for all of these

### DIFF
--- a/lambdas/image_processor/.snyk
+++ b/lambdas/image_processor/.snyk
@@ -13,39 +13,64 @@ ignore:
   SNYK-DEBIAN13-AOM-17385949:
     - '*':
         reason: "There is no fixed version for Debian:13 aom"
-        expires: "2026-07-17T00:00:00.000Z"
+        expires: "2026-08-30T00:00:00.000Z"
 
   SNYK-DEBIAN13-AOM-17385941:
     - '*':
         reason: "There is no fixed version for Debian:13 aom"
-        expires: "2026-07-17T00:00:00.000Z"
+        expires: "2026-08-30T00:00:00.000Z"
 
   SNYK-DEBIAN13-LIBHEIF-16895065:
     - '*':
         reason: "There is no fixed version for Debian:13 libheif"
-        expires: "2026-07-17T00:00:00.000Z"
+        expires: "2026-08-30T00:00:00.000Z"
 
   SNYK-DEBIAN13-EXPAT-16650098:
     - '*':
         reason: "There is no fixed version for Debian:13 expat"
-        expires: "2026-07-17T00:00:00.000Z"
+        expires: "2026-08-30T00:00:00.000Z"
 
   SNYK-DEBIAN13-LIBSSH2-17662015:
     - '*':
         reason: "There is no fixed version for Debian:13 libssh2"
-        expires: "2026-07-17T00:00:00.000Z"
+        expires: "2026-08-30T00:00:00.000Z"
 
   SNYK-DEBIAN13-TIFF-17690412:
     - '*':
         reason: "There is no fixed version for Debian:13 tiff"
-        expires: "2026-07-17T00:00:00.000Z"
+        expires: "2026-08-30T00:00:00.000Z"
 
   SNYK-DEBIAN13-ATTR-17678182:
     - '*':
         reason: "There is no fixed version for Debian:13 attr"
-        expires: "2026-07-17T00:00:00.000Z"
+        expires: "2026-08-30T00:00:00.000Z"
 
   SNYK-DEBIAN13-ACL-17677866:
     - '*':
         reason: "There is no fixed version for Debian:13 acl"
-        expires: "2026-07-17T00:00:00.000Z"
+        expires: "2026-08-30T00:00:00.000Z"
+
+  SNYK-DEBIAN13-LIBSSH2-18300234:
+      - '*':
+          reason: "There is no fixed version for Debian:13 libssh2"
+          expires: "2026-08-30T00:00:00.000Z"
+
+  SNYK-DEBIAN13-LIBSSH2-18300254:
+        - '*':
+            reason: "There is no fixed version for Debian:13 libssh2"
+            expires: "2026-08-30T00:00:00.000Z"
+
+  SNYK-DEBIAN13-LIBSSH2-18300251:
+          - '*':
+              reason: "There is no fixed version for Debian:13 libssh2"
+              expires: "2026-08-30T00:00:00.000Z"
+
+ SNYK-DEBIAN13-LIBSSH2-18300245:
+            - '*':
+                reason: "There is no fixed version for Debian:13 libssh2"
+                expires: "2026-08-30T00:00:00.000Z"
+
+ SNYK-DEBIAN13-LIBHEIF-17368649:
+             - '*':
+                 reason: "There is no fixed version for Debian:13 libheif"
+                 expires: "2026-08-30T00:00:00.000Z"

--- a/lambdas/image_processor/.snyk
+++ b/lambdas/image_processor/.snyk
@@ -65,12 +65,12 @@ ignore:
               reason: "There is no fixed version for Debian:13 libssh2"
               expires: "2026-08-30T00:00:00.000Z"
 
- SNYK-DEBIAN13-LIBSSH2-18300245:
-            - '*':
-                reason: "There is no fixed version for Debian:13 libssh2"
-                expires: "2026-08-30T00:00:00.000Z"
+  SNYK-DEBIAN13-LIBSSH2-18300245:
+          - '*':
+              reason: "There is no fixed version for Debian:13 libssh2"
+              expires: "2026-08-30T00:00:00.000Z"
 
- SNYK-DEBIAN13-LIBHEIF-17368649:
-             - '*':
-                 reason: "There is no fixed version for Debian:13 libheif"
-                 expires: "2026-08-30T00:00:00.000Z"
+  SNYK-DEBIAN13-LIBHEIF-17368649:
+          - '*':
+              reason: "There is no fixed version for Debian:13 libheif"
+              expires: "2026-08-30T00:00:00.000Z"


### PR DESCRIPTION
# Purpose

_Briefly describe the purpose of the change._

## Approach

Blocked by the Debian base image (like these libssh2 and your earlier expat alert). These typically require waiting for Debian or changing the base image rather than changing your application code.

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
